### PR TITLE
Webhooks unregistering during disabling ExApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.1 - 2024-10-10]
+
+### Fixed
+
+- Unregister webhooks from the Nextcloud instance during ExApp disabling.
+
 ## [1.0.0 - 2024-09-13]
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@ Flow is the key to unlocking enhanced productivity in Nextcloud, designed to be 
 **Requires [`AppAPI`](https://github.com/nextcloud/app_api) and `webhook_listeners` to be enabled to work.**
 
 	]]></description>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<licence>agpl</licence>
 	<author mail="julien-nc@posteo.net" homepage="https://github.com/julien-nc">Julien Veyssier</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -38,7 +38,7 @@ Flow is the key to unlocking enhanced productivity in Nextcloud, designed to be 
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>cloud-py-api/flow</image>
-			<image-tag>1.0.0</image-tag>
+			<image-tag>1.0.1</image-tag>
 		</docker-install>
 		<scopes>
 			<value>ALL</value>

--- a/ex_app/lib/main.py
+++ b/ex_app/lib/main.py
@@ -185,6 +185,7 @@ def enabled_handler(enabled: bool, nc: NextcloudApp) -> str:
         LOGGER.info("Bye bye from %s", nc.app_cfg.app_name)
         nc.ui.resources.delete_script("top_menu", "flow", "ex_app/js/flow-main")
         nc.ui.top_menu.unregister("flow")
+        nc.webhooks.unregister_all()
     return ""
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-nc_py_api[app]>=0.17.1
+nc_py_api[app]>=0.18.0


### PR DESCRIPTION
Although AppAPI unregisters all webhooks when Flow ExApp get  deleted, it would be wiser for ExApp to unregister them when you turn off the application, for the sake of clarity.