### PR TITLE
added replacing of "space" in Nextcloud username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Warning "sudo: unable to resolve host" during container startup. #11
 - Incorrect handling Windmill scripts with no modules in it. [commit](https://github.com/cloud-py-api/flow/commit/c8bf8309e85b14c2b36913469a38291f2c480b53)
 - Unregister webhooks from the Nextcloud instance during ExApp disabling. #10
+- Error when username(userid) contained a space. #13
 - Updated NPM packages. #12
 
 ## [1.0.0 - 2024-09-13]

--- a/ex_app/lib/main.py
+++ b/ex_app/lib/main.py
@@ -49,6 +49,7 @@ if USERS_STORAGE_PATH.exists():
 
 
 def get_user_email(user_name: str) -> str:
+    user_name = user_name.replace(" ", "__UNIQUE_SPACE__")
     return f"{user_name}@windmill.dev"
 
 


### PR DESCRIPTION
This is only for instance administrators, only for them a Windmill account is "created" when logging into ExApp.

Nextcloud supports usernames with spaces, so we replace spaces with "__UNIQUE_SPACE__"

The chance of a collision is extremely small, let's hope that there won't be two admin users with such userids:
`admin some`
`admin__UNIQUE_SPACE__some`